### PR TITLE
Fix issues with retrieving DataFrames

### DIFF
--- a/cognite/model_hosting/data_fetcher/data_fetcher.py
+++ b/cognite/model_hosting/data_fetcher/data_fetcher.py
@@ -177,6 +177,8 @@ class TimeSeriesFetcher:
         seen = {}
         for alias in aliases:
             ts_id = self._specs[alias].id
+            if ts_id is None:
+                ts_id = self._cdp_client.cognite_client.time_series.retrieve(external_id=self._specs[alias].external_id).id
             if ts_id in seen:
                 raise InvalidFetchRequest(
                     "Aliases {} and {} reference the same time series: {}".format(alias, seen[ts_id], ts_id)
@@ -227,7 +229,8 @@ class TimeSeriesFetcher:
             if spec.id:
                 time_series.append({"id": spec.id, "aggregates": [spec.aggregate]})
             elif spec.external_id:
-                time_series.append({"externalId": spec.external_id, "aggregates": [spec.aggregate]})
+                ts_id = self._cdp_client.cognite_client.time_series.retrieve(external_id=spec.external_id).id
+                time_series.append({"id": ts_id, "aggregates": [spec.aggregate]})        
         start, end, granularity = self._get_common_start_end_granularity(aliases)
         df = self._cdp_client.get_datapoints_frame(time_series, granularity, start, end)
         df.columns = aliases


### PR DESCRIPTION
It is not possible to retrieve a DataFrame using external IDs in the TimeSeriesSpecs. This is fixed by converting the extenral IDs to IDs. See issue #64 .